### PR TITLE
Update Reflets-4.html

### DIFF
--- a/Reflets/Reflets-4.html
+++ b/Reflets/Reflets-4.html
@@ -186,7 +186,7 @@ NARRATEUR : Les retombées cycliques de gouttes en souffrance brisaient avec éc
 WRANDRALL : (plic ...plic) C'est fini oui, bordel ?!
 ENORIEL : Quelques alexandrins et vous voilà outrés !REF:C'est la première fois qu'un personnage admet faire des rimes et parler en vers !
 NARRATEUR : Et dire qu'avec finesse, l'ambiance se posait !
-ZARAKAÏ : La ferme espèce de Cagouille !REF:Une cagouille désigne un escargot en occitan
+ZARAKAÏ : La ferme espèce de Cagouille !REF:Une cagouille désigne un escargot en charentais
 ENORIEL : Méfiez-vous d'assurer le posé de vos pieds : le sol est encombré, et glissant qui plus est !JDM:Les alexandrins continuent : avec hémistiche en vers normands qui plus est !
 NARRATEUR : Ecoutant Enoriel prodiguant ses conseils, ils avancèrent en choeur...avec grâce et candeur.JDM:Alexandrins toujours, plus hémistiche-vers normands sur le deuxième ver.
 ZARAKAÏ : c'est qui ça...grâce et candeur ?JDM:Avec grâce et candeur... elle était facile celle-là !


### PR DESCRIPTION
Le mot cagouille pourrait provenir de l'ancien occitan mais n'est utilisé que dans les Charentes.