### PR TITLE
Correction REF narrateur pacte sang

### DIFF
--- a/Reflets/Reflets-1.html
+++ b/Reflets/Reflets-1.html
@@ -323,7 +323,7 @@ WRANDRALL : pas le temps, pas le temps ! On en parlera dans deux heures, à la s
 TOUS : oui !
 NARRATEUR : Pfff... bon bé... on y va alors...
 TOUS : oui !
-NARRATEUR : Les membres du groupe désormais liés par un pacte de sang...REF:*Le Pacte Du Sang*, un film de Renny Harlin.
+NARRATEUR : Les membres du groupe désormais liés par un pacte de sang...REF:Prémonition du pacte décisif qui aura lieu à l'épisode 16...
 TOUS : ça va pas non !
 NARRATEUR : ... euh... liés par un pacte d'amitiéREF:Le pacte d'amitié est moins puissant que le pacte de sang. Quant au pacte vénal, il est hors-catégories !
 TOUS : pas du tout !


### PR DESCRIPTION
Le film "Le Pacte du Sang" date de 2006 alors que Reflets d'Acide a commencé en 2004. Impossible donc qu'il s'agisse d'une référence à ce film. En revanche, c'est aussi le nom d'un roman de Dominique Rocher paru en 1970 (qui n'a rien à voir avec le film). C'est aussi et surtout une prémonition de ce qui se passera dans l'épisode 16.